### PR TITLE
Convenience functions for verifying mocks

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"testing"
 
 	"github.com/kr/pretty"
 )
@@ -136,6 +137,13 @@ func VerifyMocks(mocks ...HasVerify) (bool, error) {
 		}
 	}
 	return true, nil
+}
+
+// Fail the test if any of the mocks fail verification
+func AssertVerifyMocks(t *testing.T, mocks ...HasVerify) {
+	if ok, err := VerifyMocks(mocks...); !ok {
+		t.Error(err)
+	}
 }
 
 // Reset removes all stubs defined.

--- a/mock.go
+++ b/mock.go
@@ -123,6 +123,21 @@ func (m *Mock) Verify() (bool, error) {
 	return true, nil
 }
 
+// HasVerify is used as the input of VerifyMocks (Mock satisfies it, obviously)
+type HasVerify interface {
+	Verify() (bool, error)
+}
+
+// VerifyMocks verifies a list of mocks, and returns the first error, if any.
+func VerifyMocks(mocks ...HasVerify) (bool, error) {
+	for _, m := range mocks {
+		if ok, err := m.Verify(); !ok {
+			return ok, err
+		}
+	}
+	return true, nil
+}
+
 // Reset removes all stubs defined.
 func (m *Mock) Reset() *Mock {
 	m.Functions = nil

--- a/mock_test.go
+++ b/mock_test.go
@@ -703,3 +703,22 @@ func TestMockResultDefaults(t *testing.T) {
 		t.Error("fail")
 	}
 }
+
+func TestVerifyMocks(t *testing.T) {
+	good := &Mock{}
+	bad1 := &Mock{}
+	bad2 := &Mock{}
+	bad1.When("foo").Times(1)
+	bad1.When("bar").Times(1)
+	if ok, err := VerifyMocks(good, good, good); !ok {
+		t.Error(err)
+	}
+	ok, err := VerifyMocks(good, bad1, bad2)
+	if ok {
+		t.Fail()
+	}
+	_, bad1Error := bad1.Verify()
+	if err.Error() != bad1Error.Error() {
+		t.Errorf("Expected verification error %s, found %s", bad1Error, err)
+	}
+}


### PR DESCRIPTION
I found myself writing these the first time I used `go-mock` today. It feels like "VerifyMocks" is something that would be nice to have in the library. I'm not sure you want to have assertions like "AssertVerifyMocks", I'm happy to remove it from the PR if that doesn't fit the design you have in mind.

I'm not sure if you want this, so I left documentation out for now. Happy to add documentation if you want to move forward with this.