### PR TITLE
Fix .Timeout() with mutexes (broken with #10)

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -267,7 +267,13 @@ func (m *Mock) When(name string, arguments ...interface{}) *MockFunction {
 //			return r.Int(0), r.String(1), r.Error(2)
 // 		}
 func (m *Mock) Called(arguments ...interface{}) *MockResult {
-	defer m.mutex.Unlock()
+	var timeout time.Duration
+	defer func() {
+		m.mutex.Unlock()
+		if timeout > 0 {
+			time.Sleep(timeout)
+		}
+	}()
 	m.mutex.Lock()
 
 	pc, _, _, ok := runtime.Caller(1)
@@ -312,9 +318,7 @@ func (m *Mock) Called(arguments ...interface{}) *MockResult {
 			}
 		}
 
-		if f.timeout > 0 {
-			time.Sleep(f.timeout)
-		}
+		timeout = f.timeout
 
 		if f.PanicValue != nil {
 			panic(f.PanicValue)


### PR DESCRIPTION
in #10 we added a mutex around .Called(), but this causes an issue when
the mock has .Timeout() set. Currently all callers to the mock are
locked out for this timeout.

As a simple fix, wait to do the sleep until
after we have finished the method and unlocked the mutex.