### PR TITLE
Fix Call returning the first set of values each time when called

### DIFF
--- a/mock.go
+++ b/mock.go
@@ -313,6 +313,7 @@ func (m *Mock) Called(arguments ...interface{}) *MockResult {
 				values = f.call.Call(values)
 			}
 
+			f.ReturnValues = make([]interface{}, 0, len(values))
 			for i := range values {
 				f.ReturnValues = append(f.ReturnValues, values[i].Interface())
 			}

--- a/mock_test.go
+++ b/mock_test.go
@@ -566,6 +566,11 @@ func TestCall(t *testing.T) {
 	m.When("FuncWithArgs", 6, "string").Call(func(a int, b string, c int) (int, string) {
 		return a * c, b + b
 	}).Times(1)
+	i := 0
+	m.When("FuncNoArgs").Call(func() int {
+		i += 1
+		return i
+	})
 
 	a, b := m.FuncWithArgs(1, "string")
 	if a != 2 || b != "stringstring" {
@@ -594,6 +599,13 @@ func TestCall(t *testing.T) {
 
 	a, b = m.FuncWithArgs(6, "string")
 	if a != 0 || b != "stringstring" {
+		t.Error("fail")
+	}
+
+	if m.FuncNoArgs() != 1 {
+		t.Error("fail")
+	}
+	if m.FuncNoArgs() != 2 {
 		t.Error("fail")
 	}
 


### PR DESCRIPTION
Fixes the issue I reported (#12) where calling a function which is mocked using MockFunction.Call and may return different values each time only ever returns the values from the first invocation (despite the function passed to MockFunction.Call being invoked again)