### PR TITLE
Use cmp.Equal before trying reflect.DeepEqual

### DIFF
--- a/cmp_test.go
+++ b/cmp_test.go
@@ -27,9 +27,13 @@ func TestCompareUsingGoCmp(t *testing.T) {
 	foo := &EqualMe{"foo"}
 	FOO := &EqualMe{"FOO"}
 
-	sut.When("Call", foo).Return(struct{}{})
+	sut.When("Call", foo).Return(struct{}{}).Times(1)
 
 	sut.Call(FOO)
 
-	sut.Verify()
+	ok, err := sut.Verify()
+	if !ok {
+		t.Error(err)
+	}
+
 }

--- a/cmp_test.go
+++ b/cmp_test.go
@@ -1,0 +1,35 @@
+package mock
+
+import (
+	"strings"
+	"testing"
+)
+
+type EqualMe struct {
+	s string
+}
+
+func (x *EqualMe) Equal(y *EqualMe) bool {
+	return strings.ToLower(x.s) == strings.ToLower(y.s)
+}
+
+type MyMock struct {
+	Mock
+}
+
+func (m *MyMock) Call(e *EqualMe) {
+	m.Called(e)
+}
+
+func TestCompareUsingGoCmp(t *testing.T) {
+	sut := &MyMock{}
+
+	foo := &EqualMe{"foo"}
+	FOO := &EqualMe{"FOO"}
+
+	sut.When("Call", foo).Return(struct{}{})
+
+	sut.Call(FOO)
+
+	sut.Verify()
+}

--- a/cmp_test.go
+++ b/cmp_test.go
@@ -9,6 +9,10 @@ type EqualMe struct {
 	s string
 }
 
+type EqualMeToo struct {
+	s string
+}
+
 func (x *EqualMe) Equal(y *EqualMe) bool {
 	return strings.ToLower(x.s) == strings.ToLower(y.s)
 }
@@ -18,6 +22,10 @@ type MyMock struct {
 }
 
 func (m *MyMock) Call(e *EqualMe) {
+	m.Called(e)
+}
+
+func (m *MyMock) CallToo(e *EqualMeToo) {
 	m.Called(e)
 }
 
@@ -37,3 +45,4 @@ func TestCompareUsingGoCmp(t *testing.T) {
 	}
 
 }
+

--- a/messages_test.go
+++ b/messages_test.go
@@ -1,0 +1,87 @@
+package mock
+
+import (
+	"testing"
+	"fmt"
+	"strings"
+)
+
+type arg struct {
+	V string
+}
+
+func (a *arg) String() string {
+	return fmt.Sprintf("anArg: %s", a.V)
+}
+
+type myMock struct {
+	Mock
+}
+
+func (m *myMock) SomeFunc(a arg) {
+	m.Called(a)
+}
+
+func (m *myMock) HasTwoArgs(a arg, b *arg) {
+	m.Called(a, b)
+}
+
+func TestMessageFromAnyIf(t *testing.T) {
+	m := &myMock{}
+
+	m.When("SomeFunc", AnyIf("a struct with foo", func(i interface{}) bool {
+		a, ok := i.(arg)
+		return ok && a.V == "foo"
+	}))
+
+	defer assertMessageContains(t, "a struct with foo")
+	m.SomeFunc(arg { "bar"})
+
+}
+
+func TestMessageFromArg(t *testing.T) {
+	m := &myMock{}
+
+	m.When("SomeFunc", arg { "foo"})
+
+	defer assertMessageContains(t, "SomeFunc({V:foo})")
+	m.SomeFunc(arg{"bar"})
+
+}
+
+func TestMessageFromAnyOfType(t *testing.T) {
+	m := &myMock{}
+
+	m.When("SomeFunc", AnyOfType("string"))
+
+	defer assertMessageContains(t, "SomeFunc(string)")
+	m.SomeFunc(arg{"bar"})
+
+}
+
+func TestMessageForAnyAndType(t *testing.T) {
+	m := &myMock{}
+
+	m.When("HasTwoArgs", Any, AnyOfType("string"))
+
+	defer assertMessageContains(t, "HasTwoArgs(mock.any, string)")
+	m.HasTwoArgs(arg{"bar"}, &arg{"baz"})
+
+}
+
+func TestMessageForAnyAndNil(t *testing.T) {
+	m := &myMock{}
+
+	m.When("HasTwoArgs", Any, nil)
+
+	defer assertMessageContains(t, "HasTwoArgs(mock.any, <nil>)")
+	m.HasTwoArgs(arg{"bar"}, &arg{"bar"})
+
+}
+
+func assertMessageContains(t *testing.T, expected string) {
+	err := recover()
+	if !strings.Contains(fmt.Sprintf("%s", err), expected) {
+		t.Fatalf("%s", err)
+	}
+}

--- a/mock.go
+++ b/mock.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kr/pretty"
+	//"github.com/kr/pretty"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -363,15 +363,16 @@ func (m *Mock) Called(arguments ...interface{}) *MockResult {
 	if len(arguments) == 0 {
 		msg = fmt.Sprintf("Mock call missing for %s()", functionName)
 	} else {
-		argsStr := pretty.Sprintf("%# v", arguments)
-		argsStr = argsStr[15 : len(argsStr)-1]
+		//argsStr := pretty.Sprintf("%# v", arguments)
+		//argsStr = argsStr[15 : len(argsStr)-1]
+		argsStr := fmt.Sprintf("%+v", arguments)
 
 		alts := ""
 		for _, altMsg := range alternatives {
 			alts += fmt.Sprintf("\t%s\n", altMsg)
 		}
 
-		msg = fmt.Sprintf("Mock call missing for %s(%s)\nExpected calls:\n%s", functionName, argsStr, alts)
+		msg = fmt.Sprintf("Mock call missing for:\n%s(%s)\nExpected calls:\n%s\n", functionName, argsStr, alts)
 	}
 	panic(msg)
 }

--- a/mock.go
+++ b/mock.go
@@ -89,7 +89,11 @@ func AnyOfType(t string) AnythingOfType {
 }
 
 // AnyIfType defines the type used as an argument that satisfies a condition.
-type AnyIfType func(interface{}) bool
+type AnyIfType struct {
+	cond func(interface{}) bool
+	description string
+}
+
 
 // AnyIf is a helper to define AnyIfType arguments.
 //
@@ -99,8 +103,8 @@ type AnyIfType func(interface{}) bool
 // 			return ok && ii.ID = "the-id"
 // 		}
 // 		mock.When("MyMethod", mock.AnyIf(f)).Return(0)
-func AnyIf(f func(interface{}) bool) AnyIfType {
-	return AnyIfType(f)
+func AnyIf(description string, f func(interface{}) bool) AnyIfType {
+	return AnyIfType{f, description}
 }
 
 // RestType indicates there may optionally be one or more remaining elements.
@@ -118,7 +122,7 @@ func match(actual, expected interface{}) bool {
 		return true
 
 	case AnyIfType:
-		return expected(actual)
+		return expected.cond(actual)
 
 	case AnythingOfType:
 		return reflect.TypeOf(actual).String() == string(expected)
@@ -147,7 +151,7 @@ func match(actual, expected interface{}) bool {
 // Example:
 //     mock.When("MyMethod", mock.Slice(123, mock.Rest)).Return(0)
 func Slice(elements ...interface{}) AnyIfType {
-	return AnyIf(func(argument interface{}) bool {
+	return AnyIf(fmt.Sprintf("Slice(%s)", elements), func(argument interface{}) bool {
 		var v = reflect.ValueOf(argument)
 
 		if v.Kind() != reflect.Slice {
@@ -284,7 +288,8 @@ func (m *Mock) Called(arguments ...interface{}) *MockResult {
 	parts := strings.Split(functionPath, ".")
 	functionName := parts[len(parts)-1]
 
-	if f := m.find(functionName, arguments...); f != nil {
+	f, alternatives := m.find(functionName, arguments...)
+	if f != nil {
 		// Increase the counter
 		f.count++
 		f.order = m.order
@@ -360,13 +365,20 @@ func (m *Mock) Called(arguments ...interface{}) *MockResult {
 	} else {
 		argsStr := pretty.Sprintf("%# v", arguments)
 		argsStr = argsStr[15 : len(argsStr)-1]
-		msg = fmt.Sprintf("Mock call missing for %s(%s)", functionName, argsStr)
+
+		alts := ""
+		for _, altMsg := range alternatives {
+			alts += fmt.Sprintf("\t%s\n", altMsg)
+		}
+
+		msg = fmt.Sprintf("Mock call missing for %s(%s)\nExpected calls:\n%s", functionName, argsStr, alts)
 	}
 	panic(msg)
 }
 
-func (m *Mock) find(name string, arguments ...interface{}) *MockFunction {
+func (m *Mock) find(name string, arguments ...interface{}) (*MockFunction, []string) {
 	var ff *MockFunction
+	var alternatives []string
 
 	for _, f := range m.Functions {
 		if f.Name != name {
@@ -378,38 +390,40 @@ func (m *Mock) find(name string, arguments ...interface{}) *MockFunction {
 		}
 
 		found := true
+		alternative := name + "("
 		for i, arg := range f.Arguments {
 			switch arg.(type) {
 			case AnyType:
-				continue
+				// do nothing on purpose
 			case AnythingOfType:
-				if string(arg.(AnythingOfType)) == reflect.TypeOf(arguments[i]).String() {
-					continue
-				} else {
+				if argType := string(arg.(AnythingOfType)); argType != reflect.TypeOf(arguments[i]).String() {
 					found = false
 				}
 			case AnyIfType:
-				cond, ok := arg.(AnyIfType)
-				if ok && cond(arguments[i]) {
-					continue
-				} else {
+				anyIf, ok := arg.(AnyIfType)
+				if !ok || !anyIf.cond(arguments[i]) {
 					found = false
 				}
 			default:
 				v := reflect.ValueOf(arguments[i])
-				if arg == nil && (arguments[i] == nil || (v.CanInterface() && v.IsNil())) {
-					continue
-				}
+				bothAreNil := arg == nil && (arguments[i] == nil || (v.CanInterface() && v.IsNil()))
 
-				if cmp.Equal(arg, arguments[i]) || reflect.DeepEqual(arg, arguments[i]) || reflect.ValueOf(arg) == reflect.ValueOf(arguments[i]) {
-					continue
-				} else {
+				if !(bothAreNil || cmp.Equal(arg, arguments[i]) || reflect.DeepEqual(arg, arguments[i])) && reflect.ValueOf(arg) != reflect.ValueOf(arguments[i]) {
 					found = false
 				}
 			}
+
+			alternative += fmt.Sprintf("%+v", arg)
+
+			if i < len(f.Arguments) - 1 {
+				alternative += ", "
+			}
 		}
 
+		alternative += ")"
+
 		if !found {
+			alternatives = append(alternatives, alternative)
 			continue
 		}
 
@@ -422,10 +436,10 @@ func (m *Mock) find(name string, arguments ...interface{}) *MockFunction {
 			continue
 		}
 
-		return f
+		return f, alternatives
 	}
 
-	return ff
+	return ff, alternatives
 }
 
 // Return defines the return values of a *MockFunction.

--- a/mock.go
+++ b/mock.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/kr/pretty"
+	"github.com/google/go-cmp/cmp"
 )
 
 // Mock should be embedded in the struct that we want to act as a Mock.
@@ -400,7 +401,7 @@ func (m *Mock) find(name string, arguments ...interface{}) *MockFunction {
 					continue
 				}
 
-				if reflect.DeepEqual(arg, arguments[i]) || reflect.ValueOf(arg) == reflect.ValueOf(arguments[i]) {
+				if cmp.Equal(arg, arguments[i]) || reflect.DeepEqual(arg, arguments[i]) || reflect.ValueOf(arg) == reflect.ValueOf(arguments[i]) {
 					continue
 				} else {
 					found = false

--- a/mock_test.go
+++ b/mock_test.go
@@ -228,7 +228,7 @@ func TestAny(t *testing.T) {
 	m.When("FuncWithArgs", 1, Any).Return(2, "booh").Times(1)
 	m.When("FuncWithArgs", 2, Any).Return(4, "booh").Times(2)
 	m.When("FuncWithArgs", AnyOfType("int"), AnyOfType("string")).Return(6, "booh").Times(2)
-	m.When("FuncWithArgs", AnyIf(f1), AnyIf(f2)).Return(8, "booh").Times(2)
+	m.When("FuncWithArgs", AnyIf("5 or 6", f1), AnyIf("foo", f2)).Return(8, "booh").Times(2)
 
 	a, b := m.FuncWithArgs(1, "string")
 	if a != 2 || b != "booh" {
@@ -346,7 +346,7 @@ func TestAnyIfNotFound(t *testing.T) {
 		return ok && ii == 2
 	}
 
-	m.When("FuncWithArgs", AnyIf(f1), "foo").Return(2, "stringstring")
+	m.When("FuncWithArgs", AnyIf("2", f1), "foo").Return(2, "stringstring")
 	m.FuncWithArgs(1, "foo")
 }
 


### PR DESCRIPTION
`reflect.DeepEqual` is a problematic function that does not support providing customized equality functions. We had a use case where our mocks were failing to register a call because one of the arguments did not pass `DeepEqual`'s equality test because of unexported fields that should not be taken into account for equality purposes. This PR aims to help work around this issue.